### PR TITLE
Changed the hardcoding of the Documents Folder to the Enviromentvariable

### DIFF
--- a/legacy-chatfilter/Program.cs
+++ b/legacy-chatfilter/Program.cs
@@ -12,7 +12,7 @@ namespace legacy_chatfilter
             string chatFilterLocation;
 
             // First step, check if the file already exists or not - if it is, it is located at C:\Users\%username%\Documents\Guild Wars\ChatFilter.ini
-            chatFilterLocation = @"C:\Users\" + @Environment.UserName + @"\Documents\Guild Wars\";
+            chatFilterLocation = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments) + @"\Guild Wars\";
             if (File.Exists(chatFilterLocation + "ChatFilter.ini"))
             {
                 // File exists. Check if the file on the server matches or not.


### PR DESCRIPTION
Changed the hardcoded path to Documents to the Enviromentvariable. This should support languages, which doesn't save in C:\Users and who uses custom paths.

This will fix #46 and it's currently tested on Windows 10 x64 with German Language.
